### PR TITLE
Multiple changes to how managed memory is accessed

### DIFF
--- a/data/array.h
+++ b/data/array.h
@@ -11,10 +11,14 @@
 
 #include "common/common.h"
 #include "memory/heap.h"
+#include "memory/ptr.h"
 
 namespace codeswitch {
 
-/** A fixed-length contiguous range of elements. */
+/**
+ * A contiguous list of elements. The length is set at allocation time. The
+ * array doesn't store the length, so it performs no bounds checking.
+ */
 template <class T>
 class Array {
  public:
@@ -24,13 +28,14 @@ class Array {
 
   const T& at(length_t i) const { return (*this)[i]; }
   T& at(length_t i) { return (*this)[i]; }
-  const T& operator[](length_t i) const { return data_[i]; }
-  T& operator[](length_t i) { return data_[i]; }
-  const Array* slice(length_t i) const;
-  Array* slice(length_t i);
+  const T& operator[](length_t i) const { return *(begin() + i); }
+  T& operator[](length_t i) { return *(begin() + i); }
 
- private:
-  T data_[0];
+  const T* begin() const { return const_cast<Array<T>*>(this)->begin(); }
+  T* begin() { return reinterpret_cast<T*>(this); }
+
+  const Array<T>* slice(length_t i) const { return const_cast<Array<T>*>(this)->slice(i); }
+  Array<T>* slice(length_t i);
 };
 
 template <class T>
@@ -39,13 +44,56 @@ Array<T>* Array<T>::make(length_t length) {
 }
 
 template <class T>
-const Array<T>* Array<T>::slice(length_t i) const {
-  return reinterpret_cast<const Array<T>*>(&data_[i]);
+Array<T>* Array<T>::slice(length_t i) {
+  return reinterpret_cast<Array<T>*>(reinterpret_cast<address>(this) + i * sizeof(T));
 }
 
 template <class T>
-Array<T>* Array<T>::slice(length_t i) {
-  return reinterpret_cast<Array<T>*>(&data_[i]);
+class BoundArray {
+ public:
+  BoundArray() = default;
+  BoundArray(Array<T>* array, length_t length) : array_(array), length_(length) {}
+
+  length_t length() const { return length_; }
+  const T& at(length_t i) const { return const_cast<BoundArray<T>*>(this)->at(i); }
+  T& at(length_t i) { return (*this)[i]; }
+  const T& operator[](length_t i) const { return (*const_cast<BoundArray<T>*>(this))[i]; }
+  T& operator[](length_t i);
+
+  const T* begin() const { return const_cast<BoundArray<T>*>(this)->begin(); }
+  T* begin() { return array_->begin(); }
+  const T* end() const { return const_cast<BoundArray<T>*>(this)->end(); }
+  T* end() { return array_->begin() + length_; }
+
+  void slice(length_t i, length_t j);
+  void set(Array<T>* array, length_t length);
+
+ private:
+  Ptr<Array<T>> array_;
+  length_t length_ = 0;
+};
+
+template <class T>
+T& BoundArray<T>::operator[](length_t i) {
+  if (i >= length_) {
+    throw BoundsCheckError();
+  }
+  return array_->at(i);
+}
+
+template <class T>
+void BoundArray<T>::slice(length_t i, length_t j) {
+  if (j > length_ || i > j) {
+    throw BoundsCheckError();
+  }
+  array_ = array_->slice(i);
+  length_ = j - i;
+}
+
+template <class T>
+void BoundArray<T>::set(Array<T>* array, length_t length) {
+  array_.set(array);
+  length_ = length;
 }
 
 }  // namespace codeswitch

--- a/data/list_test.cpp
+++ b/data/list_test.cpp
@@ -6,14 +6,18 @@
 #include "test/test.h"
 
 #include "list.h"
+#include "memory/handle.h"
 
 namespace codeswitch {
 
 TEST(ListBasic) {
-  auto list = List<int>::make(3);
+  auto list = handle(List<int>::make());
+  ASSERT_EQ(list->length(), static_cast<length_t>(0));
+  ASSERT_EQ(list->cap(), static_cast<length_t>(0));
+
+  list->reserve(3);
   ASSERT_EQ(list->length(), static_cast<length_t>(0));
   ASSERT_EQ(list->cap(), static_cast<length_t>(3));
-
   list->append(10);
   list->append(20);
   list->append(30);

--- a/data/map_test.cpp
+++ b/data/map_test.cpp
@@ -31,15 +31,21 @@ TEST(MapInt) {
   ASSERT_EQ(m->length(), static_cast<length_t>(100));
 }
 
+#include <vector>
+
 TEST(MapString) {
-  auto m = handle(Map<Ptr<String>, Ptr<String>, HashString>::make());
+  auto m = handle(Map<String, String, HashString>::make());
   ASSERT_EQ(m->length(), static_cast<length_t>(0));
+  std::vector<int> v;
+  v.emplace_back(12);
+
   for (int i = 0; i < 100; i++) {
-    auto key = handle(String::make(std::to_string(i)));
-    ASSERT_FALSE(m->has(key.ptr()));
-    m->set(key.ptr(), key.ptr());
-    ASSERT_TRUE(m->has(key.ptr()));
-    ASSERT_EQ(m->get(key.ptr())->compare(key.get()), 0);
+    auto s = std::to_string(i);
+    auto key = String::create(s);
+    ASSERT_FALSE(m->has(*key.get()));
+    m->set(*key.get(), *key.get());
+    ASSERT_TRUE(m->has(*key.get()));
+    ASSERT_EQ(m->get(*key.get()).compare(s), 0);
   }
 }
 

--- a/data/string.h
+++ b/data/string.h
@@ -15,26 +15,36 @@
 namespace codeswitch {
 
 /**
- * An immutable sequence of bytes representing UTF-8 encoded text.
+ * A sequence of bytes representing UTF-8 text.
+ *
+ * String is essentially a wrapper around BoundArray, so it's important not
+ * to pass by value in C++ code, since that will execute write barriers
+ * on the C++ stack, which is not allowed. Strings generally should be passed
+ * by value in managed code though.
+ *
+ * The bytes referenced by a String are immutable, though the string header
+ * itself is not.
  */
 class String {
  public:
-  void* operator new(size_t);
-  String(const String& s);
-  String(String&& s);
-  String& operator=(const String& s);
-  String& operator=(String&& s) = delete;
-  static String* make(const char* s);
-  static String* make(const std::string& s);
-  static String* make(const std::string_view& s);
+  static String* make();
+  static String* make(BoundArray<const uint8_t>& data);
+  static String* make(Array<const uint8_t>* array, length_t length);
+  static Handle<String> create(const char* s);
+  static Handle<String> create(const std::string& s);
+  static Handle<String> create(const std::string_view& s);
 
-  length_t length() const { return length_; }
-  String slice(length_t i, length_t j) const;
+  length_t length() const { return data_.length(); }
   std::string_view view() const;
+  const uint8_t* begin() const { return data_.begin(); }
+  const uint8_t* end() const { return data_.end(); }
+
+  void slice(length_t i, length_t j);
 
   intptr_t compare(const String& r) const;
-  intptr_t compare(const String* r) const { return compare(*r); }
   intptr_t compare(const char* r) const;
+  intptr_t compare(const std::string& s) const;
+  intptr_t compare(const std::string_view& s) const;
   bool operator==(const String& s) const { return compare(s) == 0; }
   bool operator!=(const String& s) const { return compare(s) != 0; }
   bool operator<(const String& s) const { return compare(s) < 0; }
@@ -43,18 +53,19 @@ class String {
   bool operator>=(const String& s) const { return compare(s) >= 0; }
 
  private:
-  friend std::ostream& operator<<(std::ostream&, String*);
+  friend std::ostream& operator<<(std::ostream&, const String&);
 
-  String(length_t length, const Array<uint8_t>* data);
+  String() = default;
+  explicit String(BoundArray<const uint8_t>& data) : data_(data) {}
+  String(Array<const uint8_t>* array, length_t length) : data_(array, length) {}
 
-  length_t length_;
-  Ptr<const Array<uint8_t>> data_;
+  BoundArray<const uint8_t> data_;
 };
 
 class HashString {
  public:
-  static word_t hash(const Ptr<String>& s);
-  static bool equal(const Ptr<String>& l, const Ptr<String>& r) { return l->compare(*r) == 0; }
+  static word_t hash(const String& s);
+  static bool equal(const String& l, const String& r) { return l.compare(r) == 0; }
 };
 
 std::ostream& operator<<(std::ostream&, String*);

--- a/data/string_test.cpp
+++ b/data/string_test.cpp
@@ -10,28 +10,47 @@
 namespace codeswitch {
 
 TEST(StringCompare) {
-  auto a = String::make("foo");
-  ASSERT_EQ(a->compare(a), 0);
+  auto a = String::create("foo");
+  ASSERT_EQ(a->compare(*a.get()), 0);
   ASSERT_EQ(a->compare("foo"), 0);
-  auto b = String::make(std::string("foo"));
-  ASSERT_EQ(a->compare(b), 0);
-  auto c = String::make("bar");
-  ASSERT_TRUE(a->compare(c) > 0);
-  ASSERT_TRUE(c->compare(a) < 0);
+  auto b = String::create(std::string("foo"));
+  ASSERT_EQ(a->compare(*b.get()), 0);
+  auto c = String::create("bar");
+  ASSERT_TRUE(a->compare(*c.get()) > 0);
+  ASSERT_TRUE(c->compare(*a.get()) < 0);
   ASSERT_TRUE(a->compare("bar") > 0);
-  ASSERT_TRUE(a->compare(a->slice(0, 2)) > 0);
+  *b.get() = *a.get();
+  b->slice(0, 2);
+  ASSERT_TRUE(a->compare(*b.get()) > 0);
 }
 
 TEST(StringSlice) {
-  auto a = String::make("abcde");
-  ASSERT_EQ(a->slice(0, 0).compare(""), 0);
-  ASSERT_EQ(a->slice(2, 2).compare(""), 0);
-  ASSERT_EQ(a->slice(5, 5).compare(""), 0);
-  ASSERT_EQ(a->slice(0, 2).compare("ab"), 0);
-  ASSERT_EQ(a->slice(2, 5).compare("cde"), 0);
+  auto a = String::create("abcde");
+  auto s = handle(String::make());
 
+  *s.get() = *a.get();
+  s->slice(0, 0);
+  ASSERT_EQ(s->compare(""), 0);
+
+  *s.get() = *a.get();
+  s->slice(2, 2);
+  ASSERT_EQ(s->compare(""), 0);
+
+  *s.get() = *a.get();
+  s->slice(5, 5);
+  ASSERT_EQ(s->compare(""), 0);
+
+  *s.get() = *a.get();
+  s->slice(0, 2);
+  ASSERT_EQ(s->compare("ab"), 0);
+
+  *s.get() = *a.get();
+  s->slice(2, 5);
+  ASSERT_EQ(s->compare("cde"), 0);
+
+  *s.get() = *a.get();
   try {
-    a->slice(0, 6);
+    s->slice(0, 6);
   } catch (BoundsCheckError& err) {
     return;
   }

--- a/interpreter/interpreter_test.cpp
+++ b/interpreter/interpreter_test.cpp
@@ -30,8 +30,8 @@ TEST(Assembly) {
     }
     std::ifstream file(filename);
     auto package = readPackageAsm(filename, file);
-    auto name = handle(String::make("main"));
-    auto entry = handle(package->findFunction(name.get()));
+    auto name = String::create("main");
+    auto entry = handle(package->findFunction(*name.get()));
     ASSERT_TRUE(entry);
 
     std::stringstream ss;

--- a/memory/handle.h
+++ b/memory/handle.h
@@ -29,21 +29,22 @@ class Handle {
   Handle& operator=(Handle&& handle);
 
   operator bool() const { return slot_; }
-  const T* get() const { return slot_->get(); }
-  T* get() { return slot_->get(); }
+  const T* get() const {
+    ASSERT(slot_);
+    return *slot_;
+  }
+  T* get() {
+    ASSERT(slot_);
+    return *slot_;
+  }
   const T* getOrNull() const { return slot_ ? slot_->get() : nullptr; }
   T* getOrNull() { return slot_ ? slot_->get() : nullptr; }
   const T* operator->() const { return get(); }
   T* operator->() { return get(); }
-  // TODO: are these actually needed? Can they be reused for get?
-  // const Ptr<T>& operator*() const { return *slot_; }
-  // Ptr<T>& operator*() { return *slot_; }
-  const Ptr<T>& ptr() const { return *slot_; }
-  Ptr<T>& ptr() { return *slot_; }
   void reset();
 
  private:
-  Ptr<T>* slot_;
+  T** slot_ = nullptr;
 };
 
 template <class T>
@@ -72,15 +73,15 @@ class HandleStorage {
 extern HandleStorage handleStorage;
 
 template <class T>
-Handle<T>::Handle(T* block) : slot_(reinterpret_cast<Ptr<T>*>(handleStorage.allocSlot())) {
-  slot_->set(block);
+Handle<T>::Handle(T* block) : slot_(reinterpret_cast<T**>(handleStorage.allocSlot())) {
+  *slot_ = block;
 }
 
 template <class T>
 Handle<T>::Handle(const Handle<T>& handle) {
   if (handle.slot_ != nullptr) {
     slot_ = reinterpret_cast<Ptr<T>*>(handleStorage.allocSlot());
-    slot_->set(handle->slot_->get())* slot_ = *handle.slot_;
+    *slot_ = *handle.slot_;
   }
 }
 

--- a/memory/ptr.h
+++ b/memory/ptr.h
@@ -21,17 +21,26 @@ template <class T>
 class alignas(word_t) Ptr {
  public:
   Ptr() : p_(nullptr) {}
-  explicit Ptr(T* q) { set(q); }
-  Ptr(const Ptr& q) { set(q.p_); }
-  Ptr(Ptr&& q) {
+  template <class S>
+  Ptr(S* q) {
+    set(q);
+  }
+  template <class S>
+  Ptr(const Ptr<S>& q) {
+    set(q.p_);
+  }
+  template <class S>
+  Ptr(Ptr<S>&& q) {
     set(q.p_);
     q.set(nullptr);
   }
-  Ptr& operator=(const Ptr& q) {
+  template <class S>
+  Ptr& operator=(const Ptr<S>& q) {
     set(q.p_);
     return *this;
   }
-  Ptr& operator=(Ptr&& q) {
+  template <class S>
+  Ptr& operator=(Ptr<S>&& q) {
     set(q.p_);
     q.set(nullptr);
     return *this;
@@ -48,12 +57,10 @@ class alignas(word_t) Ptr {
     Heap::recordWrite(&p_, q);
   }
 
-  bool operator==(T* q) { return p_ == q; }
   template <class S>
   bool operator==(const Ptr<S>& q) const {
     return p_ == q.p_;
   }
-  bool operator!=(T* q) const { return p_ != q; }
   template <class S>
   bool operator!=(const Ptr<S>& q) const {
     return p_ != q.p_;

--- a/package/BUILD.bazel
+++ b/package/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
         "function.cpp",
         "inst.cpp",
         "package.cpp",
+        "serial.cpp",
         "type.cpp",
     ],
     hdrs = [
@@ -14,6 +15,7 @@ cc_library(
         "function.h",
         "inst.h",
         "package.h",
+        "serial.h",
         "type.h",
     ],
     visibility = ["//:__subpackages__"],

--- a/package/asm.cpp
+++ b/package/asm.cpp
@@ -449,9 +449,9 @@ Handle<Package> PackageBuilder::build() {
     functionNameToIndex_[text(file_.functions[i].name)] = i;
   }
 
-  auto functions = handle(List<Ptr<Function>>::make(file_.functions.size()));
+  auto functions = List<Ptr<Function>>::create(file_.functions.size());
   for (auto& f : file_.functions) {
-    functions->append(buildFunction(f).ptr());
+    functions->append(buildFunction(f).get());
   }
   return handle(Package::make(functions.get()));
 }
@@ -463,13 +463,13 @@ struct LabelInfo {
 
 Handle<Function> PackageBuilder::buildFunction(const AsmFunction& function) {
   auto name = tokenString(function.name);
-  auto returnTypes = handle(List<Ptr<Type>>::make(function.returnTypes.size()));
+  auto returnTypes = List<Ptr<Type>>::create(function.returnTypes.size());
   for (auto& type : function.returnTypes) {
-    returnTypes->append(buildType(type).ptr());
+    returnTypes->append(buildType(type).get());
   }
-  auto paramTypes = handle(List<Ptr<Type>>::make(function.paramTypes.size()));
+  auto paramTypes = List<Ptr<Type>>::create(function.paramTypes.size());
   for (auto& type : function.paramTypes) {
-    paramTypes->append(buildType(type).ptr());
+    paramTypes->append(buildType(type).get());
   }
 
   Assembler a;
@@ -611,7 +611,7 @@ Handle<Function> PackageBuilder::buildFunction(const AsmFunction& function) {
   }
 
   auto insts = a.finish();
-  return handle(Function::make(name.get(), *returnTypes.get(), *paramTypes.get(), *insts.get(), frameSize));
+  return handle(Function::make(*name.get(), *returnTypes.get(), *paramTypes.get(), *insts.get(), frameSize));
 }  // namespace codeswitch
 
 Handle<Type> PackageBuilder::buildType(const AsmType& type) {
@@ -683,7 +683,7 @@ std::string_view PackageBuilder::identToken(Token token) {
 }
 
 Handle<String> PackageBuilder::tokenString(Token t) {
-  return handle(String::make(std::string(reinterpret_cast<const char*>(data_.data() + t.begin), t.end - t.begin)));
+  return String::create(std::string(reinterpret_cast<const char*>(data_.data() + t.begin), t.end - t.begin));
 }
 
 Assembler::Assembler() {
@@ -691,7 +691,7 @@ Assembler::Assembler() {
 }
 
 Handle<List<Inst>> Assembler::finish() {
-  auto l = handle(List<Inst>::make(size_));
+  auto l = List<Inst>::create(size_);
   for (auto& f : fragments_) {
     l->append(reinterpret_cast<Inst*>(f.begin), f.end - f.begin);
   }

--- a/package/asm_test.cpp
+++ b/package/asm_test.cpp
@@ -36,7 +36,7 @@ TEST(AssembleDisassemble) {
     for (length_t i = 0, n = package1->functions().length(); i < n; i++) {
       auto f1 = package1->functions()[i];
       auto f2 = package2->functions()[i];
-      ASSERT_TRUE(f1->name()->compare(f2->name()) == 0);
+      ASSERT_EQ(f1->name(), f2->name());
       ASSERT_EQ(f1->insts().length(), f2->insts().length());
       auto f1begin = reinterpret_cast<const uint8_t*>(&*f1->insts().begin());
       auto f1end = f1begin + f1->insts().length();

--- a/package/function.h
+++ b/package/function.h
@@ -18,22 +18,22 @@ namespace codeswitch {
 
 class Function {
  public:
-  Function(String* name, List<Ptr<Type>>& returnTypes, List<Ptr<Type>>& paramTypes, List<Inst>& insts,
+  Function(const String& name, List<Ptr<Type>>& returnTypes, List<Ptr<Type>>& paramTypes, List<Inst>& insts,
            length_t frameSize) :
       name_(name), returnTypes_(returnTypes), paramTypes_(paramTypes), insts_(insts), frameSize_(frameSize) {}
-  static Function* make(String* name, List<Ptr<Type>>& returnTypes, List<Ptr<Type>>& paramTypes, List<Inst>& insts,
-                        length_t frameSize) {
+  static Function* make(const String& name, List<Ptr<Type>>& returnTypes, List<Ptr<Type>>& paramTypes,
+                        List<Inst>& insts, length_t frameSize) {
     return new (heap.allocate(sizeof(Function))) Function(name, returnTypes, paramTypes, insts, frameSize);
   }
 
-  const String* name() const { return name_.get(); }
+  const String& name() const { return name_; }
   const List<Ptr<Type>>& returnTypes() const { return returnTypes_; }
   const List<Ptr<Type>>& paramTypes() const { return paramTypes_; }
   const List<Inst>& insts() const { return insts_; }
   length_t frameSize() const { return frameSize_; }
 
  private:
-  Ptr<String> name_;
+  String name_;
   List<Ptr<Type>> returnTypes_;
   List<Ptr<Type>> paramTypes_;
   List<Inst> insts_;

--- a/package/package.cpp
+++ b/package/package.cpp
@@ -7,9 +7,9 @@
 
 namespace codeswitch {
 
-Function* Package::findFunction(String* name) {
+Function* Package::findFunction(const String& name) {
   for (auto& fn : functions_) {
-    if (*fn->name() == *name) {
+    if (fn->name() == name) {
       return fn.get();
     }
   }

--- a/package/package.h
+++ b/package/package.h
@@ -22,7 +22,7 @@ class Package {
 
   List<Ptr<Function>>& functions() { return functions_; }
   const List<Ptr<Function>>& functions() const { return functions_; }
-  Function* findFunction(String* name);
+  Function* findFunction(const String& name);
 
  private:
   List<Ptr<Function>> functions_;

--- a/package/serial.cpp
+++ b/package/serial.cpp
@@ -1,0 +1,48 @@
+// Copyright Jay Conrod. All rights reserved.
+
+// This file is part of CodeSwitch. Use of this source code is governed by
+// the 3-clause BSD license that can be found in the LICENSE.txt file.
+
+#include "serial.h"
+
+#include <filesystem>
+#include <iostream>
+#include "common/common.h"
+#include "package.h"
+
+namespace filesystem = std::filesystem;
+
+namespace codeswitch {
+
+const uint8_t kMagic[] = {'C', 'S', 'W', 'P'};
+
+struct FileHeader {
+  uint8_t magic[4];
+  uint8_t version;
+  uint8_t endiannessAndByteSize;
+  uint16_t sectionCount;
+};
+
+namespace SectionKind {
+const uint32_t FUNCTION = 1;
+const uint32_t TYPE = 2;
+const uint32_t STRING = 3;
+}  // namespace SectionKind
+
+struct SectionHeader {
+  uint32_t kind;
+  uint32_t count;
+  uint64_t offset;
+  uint64_t dataOffset;
+};
+
+Handle<Package> readPackageBinary(const std::filesystem::path& filename, std::istream& is) {
+  UNIMPLEMENTED();
+  return Handle<Package>();
+}
+
+void writePackageBinary(std::ostream& os, const Package* package) {
+  UNIMPLEMENTED();
+}
+
+}  // namespace codeswitch

--- a/package/serial.h
+++ b/package/serial.h
@@ -1,0 +1,23 @@
+// Copyright Jay Conrod. All rights reserved.
+
+// This file is part of CodeSwitch. Use of this source code is governed by
+// the 3-clause BSD license that can be found in the LICENSE.txt file.
+
+#ifndef package_serial_h
+#define package_serial_h
+
+#include <filesystem>
+#include <iostream>
+
+namespace codeswitch {
+
+template <class T>
+class Handle;
+class Package;
+
+Handle<Package> readPackageBinary(const std::filesystem::path& filename, std::istream& is);
+void writePackageBinary(std::ostream& os, const Package* package);
+
+}  // namespace codeswitch
+
+#endif


### PR DESCRIPTION
- Handle slot is now T** instead of Ptr<T>*. There's no need for write
  barriers on handle storage since handle storage will be treated
  specially by the GC.
- Ptr<T> allows assignment from T*. Makes a lot of things simpler.
- Added BoundArray<T>, which has a Ptr<Array<T>> and a length.
- List and String are now implemented with BoundArray.