### PR TITLE
Minimal stop-the-world mark-sweep garbage collector

### DIFF
--- a/memory/chunk.cpp
+++ b/memory/chunk.cpp
@@ -5,6 +5,7 @@
 
 #include "chunk.h"
 
+#include "heap.h"
 #include "platform/platform.h"
 
 namespace codeswitch {
@@ -19,10 +20,129 @@ void Chunk::operator delete(void* addr) {
 }
 
 Chunk::Chunk(uintptr_t blockSize) :
-  blockSize_(blockSize),
-  free_(0),
-  nextFree_(reinterpret_cast<uintptr_t>(this) + kDataOffset) {
+    blockSize_(blockSize), freeList_(0), freeSpace_(reinterpret_cast<uintptr_t>(this) + kDataOffset) {
   ASSERT(isAligned(blockSize, kBlockAlignment));
+}
+
+bool Chunk::hasMark() {
+  std::lock_guard lock(mu_);
+  auto m = markBitmapLocked();
+  for (uintptr_t i = 0, n = m.wordCount(); i < n; i++) {
+    if (m.wordAt(i) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Chunk::sweep() {
+  std::lock_guard lock(mu_);
+  auto mark = markBitmapLocked();
+  auto ptr = pointerBitmapLocked();
+  auto words = reinterpret_cast<uintptr_t*>(this);
+
+  // Try to expand the free space at the end of the chunk.
+  auto beginIndex = kDataOffset / kWordSize;
+  auto origFreeIndex = (freeSpace_ - reinterpret_cast<uintptr_t>(this)) / kWordSize;
+  auto freeIndex = origFreeIndex;
+  auto wordsPerBlock = blockSize_ / kWordSize;
+  while (freeIndex > beginIndex) {
+    auto prevIndex = freeIndex - wordsPerBlock;
+    if (mark[prevIndex]) {
+      break;
+    }
+    freeIndex = prevIndex;
+  }
+  std::fill(words + freeIndex, words + origFreeIndex, 0);
+  for (uintptr_t i = freeIndex; i < origFreeIndex; i++) {
+    ptr.set(i, false);
+  }
+  freeSpace_ = reinterpret_cast<uintptr_t>(words + freeIndex);
+
+  // Rebuild the free list.
+  bytesAllocated_ = 0;
+  freeList_ = 0;
+  for (auto blockIndex = freeIndex - wordsPerBlock; blockIndex >= beginIndex; blockIndex -= wordsPerBlock) {
+    if (mark[blockIndex]) {
+      bytesAllocated_ += blockSize_;
+      continue;
+    }
+    ptr.set(blockIndex, false);
+    words[blockIndex] = freeList_;
+    freeList_ = reinterpret_cast<uintptr_t>(&words[blockIndex]);
+    for (uintptr_t i = 1; i < wordsPerBlock; i++) {
+      ptr.set(blockIndex + i, false);
+      words[blockIndex + i] = 0;
+    }
+  }
+
+  // Clear the mark bits.
+  // Pointer bits in freed blocks have already been cleared. Bits in live blocks
+  // stay set.
+  mark.clear();
+}
+
+void Chunk::validate() {
+  std::lock_guard lock(mu_);
+
+  // Validate blocks before free space.
+  auto words = reinterpret_cast<uintptr_t*>(this);
+  auto wordsPerBlock = blockSize_ / kWordSize;
+  auto freeSpaceIndex = (freeSpace_ - reinterpret_cast<uintptr_t>(this)) / kWordSize;
+  auto free = freeList_;
+  uintptr_t bytesAllocated = 0;
+  for (auto index = kDataOffset / kWordSize; index < freeSpaceIndex; index += wordsPerBlock) {
+    auto block = reinterpret_cast<uintptr_t>(&words[index]);
+    if (isMarkedLocked(block)) {
+      // Allocated block.
+      // Each word with pointer bit set must either be 0 or an address
+      // inside another marked block on the heap.
+      bytesAllocated += blockSize_;
+      for (uintptr_t i = 0; i < wordsPerBlock; i++) {
+        auto slot = reinterpret_cast<uintptr_t>(&words[index + i]);
+        if (isPointerLocked(slot) && words[index + i] != 0) {
+          auto p = words[index + i];
+          ASSERT(heap->isOnHeap(p));
+          auto c = Chunk::fromAddress(p);
+          auto caddr = reinterpret_cast<uintptr_t>(c);
+          ASSERT(caddr + Chunk::kDataOffset <= p && p <= c->freeSpace_);
+          ASSERT(c->isMarked(c->blockContaining(p)));
+        }
+      }
+    } else if (free == block) {
+      // Free block.
+      // Must be on free list.
+      // First word should be next element of free list.
+      // Other words should be 0.
+      // Pointer and other mark bits should be 0.
+      free = words[index];
+      ASSERT(!isPointerLocked(block));
+      for (uintptr_t i = 1; i < wordsPerBlock; i++) {
+        ASSERT(words[index + i] == 0);
+        auto addr = reinterpret_cast<uintptr_t>(&words[index + i]);
+        ASSERT(!isPointerLocked(addr));
+        ASSERT(!isMarkedLocked(addr));
+      }
+    } else {
+      // Dead block.
+      // Other mark bits should be 0.
+      // Nothing else checked.
+      for (uintptr_t i = 1; i < wordsPerBlock; i++) {
+        auto addr = reinterpret_cast<uintptr_t>(&words[index + i]);
+        ASSERT(!isMarkedLocked(addr));
+      }
+      bytesAllocated += blockSize_;
+    }
+  }
+  ASSERT(bytesAllocated == bytesAllocated_);
+
+  // Validate free space. Should be zeroes, no mark bits, no pointer bits.
+  for (auto index = freeSpaceIndex; index < kSize / kWordSize; index++) {
+    ASSERT(words[index] == 0);
+    auto addr = reinterpret_cast<uintptr_t>(&words[index]);
+    ASSERT(!isPointerLocked(addr));
+    ASSERT(!isMarkedLocked(addr));
+  }
 }
 
 }  // namespace codeswitch

--- a/memory/heap.cpp
+++ b/memory/heap.cpp
@@ -32,9 +32,15 @@ void* Heap::allocate(size_t size) {
     throw AllocationError(false);
   }
 
+  // If we've reached the allocation threshold, collect garbage first.
+  std::lock_guard<std::mutex> lock(mu_);
+  if (bytesAllocated_ + blockSize >= allocationLimit_) {
+    collectGarbageLocked();
+  }
+  bytesAllocated_ += blockSize;
+
   // Try to allocate from each chunk of the correct size.
   // OPT: track which chunks have free space.
-  std::lock_guard<std::mutex> lock(mu_);
   auto& chunks_ = chunksBySize_[blockSize];
   for (auto& c : chunks_) {
     auto block = c->allocate();
@@ -43,8 +49,6 @@ void* Heap::allocate(size_t size) {
     }
   }
 
-  // TODO: collect garbage when we reach some allocation threshold.
-
   // Create a new chunk, add it to the list, then allocate from that.
   chunks_.emplace_back(new Chunk(blockSize));
   auto block = chunks_.back()->allocate();
@@ -52,7 +56,25 @@ void* Heap::allocate(size_t size) {
 }
 
 void Heap::recordWrite(uintptr_t from, uintptr_t to) {
-  // TODO: implement.
+  // OPT: don't lock the heap here. This will be extremely slow.
+  std::lock_guard lock(heap->mu_);
+  setPointer(from);
+}
+
+bool Heap::isPointer(uintptr_t addr) {
+  return Chunk::fromAddress(addr)->isPointer(addr);
+}
+
+void Heap::setPointer(uintptr_t addr) {
+  Chunk::fromAddress(addr)->setPointer(addr);
+}
+
+bool Heap::isMarked(uintptr_t addr) {
+  return Chunk::fromAddress(addr)->isMarked(addr);
+}
+
+void Heap::setMarked(uintptr_t addr) {
+  return Chunk::fromAddress(addr)->setMarked(addr);
 }
 
 void Heap::checkBound(uintptr_t base, uintptr_t offset) {
@@ -78,15 +100,111 @@ uintptr_t Heap::blockSize(uintptr_t p) {
 }
 
 void Heap::collectGarbage() {
-  // TODO: implement.
+  std::lock_guard lock(mu_);
+  collectGarbageLocked();
 }
 
-void Heap::gcLock() {
-  // TODO: implement.
+void Heap::setGCLock(bool locked) {
+  std::lock_guard lock(mu_);
+  if (locked) {
+    ASSERT(gcPhase_ == GCPhase::NONE);
+    gcPhase_ = GCPhase::LOCKED;
+  } else {
+    ASSERT(gcPhase_ == GCPhase::LOCKED);
+    gcPhase_ = GCPhase::NONE;
+  }
 }
 
-void Heap::gcUnlock() {
-  // TODO: implement.
+void Heap::registerRoots(std::function<void(std::function<void(uintptr_t)>)> accept) {
+  std::lock_guard lock(mu_);
+  rootAcceptors_.push_back(accept);
+}
+
+void Heap::validate() {
+  std::lock_guard lock(mu_);
+
+  // Completely mark the heap.
+  scanRootsLocked();
+  markLocked();
+
+  // Iterate over all blocks in all chunks.
+  uintptr_t bytesAllocated = 0;
+  for (auto& sizes : chunksBySize_) {
+    for (auto& chunk : sizes.second) {
+      chunk->validate();
+      bytesAllocated += chunk->bytesAllocated();
+    }
+  }
+  ASSERT(bytesAllocated == bytesAllocated_);
+}
+
+bool Heap::isOnHeap(uintptr_t addr) {
+  for (auto& size : chunksBySize_) {
+    for (auto& chunk : size.second) {
+      if (Chunk::fromAddress(addr) == chunk.get()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void Heap::collectGarbageLocked() {
+  switch (gcPhase_) {
+    case GCPhase::LOCKED:
+      return;
+
+    case GCPhase::NONE:
+      scanRootsLocked();
+      markLocked();
+      sweepLocked();
+      allocationLimit_ = 2 * bytesAllocated_;
+      break;
+  }
+}
+
+void Heap::scanRootsLocked() {
+  auto visit = [this](uintptr_t p) {
+    if (!isMarked(p)) {
+      markStack_.push_back(p);
+    }
+  };
+  for (auto& accept : rootAcceptors_) {
+    accept(visit);
+  }
+}
+
+void Heap::markLocked() {
+  while (!markStack_.empty()) {
+    auto slot = markStack_.back();
+    markStack_.pop_back();
+    auto begin = blockContaining(slot);
+    auto end = begin + blockSize(begin);
+    setMarked(begin);
+    for (auto slot = begin; slot < end; slot += kWordSize) {
+      if (isPointer(slot)) {
+        auto p = *reinterpret_cast<uintptr_t*>(slot);
+        if (!isMarked(p)) {
+          markStack_.push_back(p);
+        }
+      }
+    }
+  }
+}
+
+void Heap::sweepLocked() {
+  uintptr_t bytesAllocated = 0;
+  for (auto& chunks : chunksBySize_) {
+    // Free chunks with no blocks allocated.
+    std::remove_if(chunks.second.begin(), chunks.second.end(), [](auto& chunk) { return !chunk->hasMark(); });
+
+    // Clean out garbage from remaining chunks.
+    for (auto& chunk : chunks.second) {
+      chunk->sweep();
+      bytesAllocated += chunk->bytesAllocated();
+    }
+  }
+  bytesAllocated_ = bytesAllocated;
 }
 
 }  // namespace codeswitch

--- a/memory/heap.h
+++ b/memory/heap.h
@@ -6,6 +6,8 @@
 #ifndef memory_heap_h
 #define memory_heap_h
 
+#include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -23,6 +25,9 @@ const uintptr_t kMinAddress = 1 << 20;
 
 /** Address returned when a 0-byte allocation is requested. */
 const uintptr_t kZeroAllocAddress = kMinAddress;
+
+/** Initial allocation threshold for triggering the garbage collector. */
+const uintptr_t kInitialAllocationLimit = 1 * MB;
 
 /**
  * Thrown when memory can't be allocated from the heap. Has a flag that
@@ -67,25 +72,91 @@ class Heap {
    * is freshly allocated, i.e., nothing else has been allocated later and no
    * pointer to that block has been stored.
    */
-  static void recordWrite(uintptr_t from, uintptr_t to);
+  void recordWrite(uintptr_t from, uintptr_t to);
 
   template <class T>
-  static void recordWrite(T** from, T* to);
+  void recordWrite(T** from, T* to);
 
   static void checkBound(uintptr_t base, uintptr_t offset);
   static uintptr_t blockContaining(uintptr_t p);
   static uintptr_t blockSize(uintptr_t p);
 
+  static bool isPointer(uintptr_t addr);
+  static void setPointer(uintptr_t addr);
+  static bool isMarked(uintptr_t addr);
+  static void setMarked(uintptr_t addr);
+
   /** Reclaim memory used by blocks that are no longer reachable. */
   void collectGarbage();
-  void gcLock();
-  void gcUnlock();
+
+  /**
+   * Prevent (or allow) garbage collection. This shouldn't be used often, but
+   * it may be useful when performing a sequence of unsafe allocations.
+   */
+  void setGCLock(bool locked);
+
+  /**
+   * Registers an "accept" function that may be called with a "visit" function.
+   * The "accept" function should call the "visit" function on a set of
+   * addresses that point into the heap, forming the roots of the pointer graph.
+   */
+  void registerRoots(std::function<void(std::function<void(uintptr_t)>)> accept);
+
+  /**
+   * Completely marks the heap, then checks internal heap invariants.
+   * Used for testing and debugging.
+   */
+  void validate();
+
+  bool isOnHeap(uintptr_t addr);
 
  private:
-  void addChunk();
+  void collectGarbageLocked();
+  void scanRootsLocked();
+  void markLocked();
+  void sweepLocked();
+
+  enum class GCPhase : int {
+    NONE,
+    LOCKED,
+  };
 
   std::mutex mu_;
+
+  /**
+   * Maps allocation sizes to lists of chunks holding blocks of those sizes.
+   * Every block in a chunk has the same size.
+   */
   std::unordered_map<size_t, std::vector<std::unique_ptr<Chunk>>> chunksBySize_;
+
+  /**
+   * Total number of bytes allocated in blocks on the heap. This only includes
+   * bytes that are part of an allocated block, not free blocks, and not
+   * other bookkeeping information that is part of a chunk.
+   */
+  uintptr_t bytesAllocated_ = 0;
+
+  /**
+   * When bytesAllocated_ exceeds this limit, collectGarbageLocked should
+   * be called. That may perform part of an incremental collection, depending
+   * on the heap and GC state.
+   */
+  uintptr_t allocationLimit_ = kInitialAllocationLimit;
+
+  /**
+   * List of "accept" functions registered with registerRoots. scanRootsLocked
+   * calls these with a function that adds unmarked roots to markStack_.
+   */
+  std::vector<std::function<void(std::function<void(uintptr_t)>)>> rootAcceptors_;
+
+  GCPhase gcPhase_ = GCPhase::NONE;
+
+  /**
+   * Holds addresses on the heap that contain pointers to potentially unmarked
+   * blocks. recordWrite and scanRoots push pointers here. markIncremental
+   * pushes and pops pointers as it traverses the block graph.
+   */
+  std::deque<uintptr_t> markStack_;
 };
 
 extern Heap* heap;

--- a/memory/ptr.h
+++ b/memory/ptr.h
@@ -54,7 +54,7 @@ class alignas(uintptr_t) Ptr {
   T* operator->() { return p_; }
   void set(T* q) {
     p_ = q;
-    Heap::recordWrite(&p_, q);
+    heap->recordWrite(&p_, q);
   }
 
   template <class S>

--- a/memory/stack.cpp
+++ b/memory/stack.cpp
@@ -5,6 +5,9 @@
 
 #include "stack.h"
 
+#include <functional>
+#include "heap.h"
+
 namespace codeswitch {
 
 // TODO: dynamic stack size.
@@ -19,6 +22,43 @@ Stack::Stack() {
 
 Stack::~Stack() {
   delete[] reinterpret_cast<uint8_t*>(limit_);
+}
+
+void Stack::accept(std::function<void(uintptr_t)> visit) {
+  // TODO: visit other pointers on the stack. Currently, the type system doesn't
+  // allow pointers, so there's actually nothing to visit. When pointers are
+  // allowed, each function needs a bitmap indicating which argument words
+  // contain pointers, and which stack slots contain pointers for each safe
+  // point. Safe points are instructions that can trigger GC, especially
+  // anything that allocates or calls.
+  for (auto fr = frame(); fr != nullptr; fr = fr->fp) {
+    visit(reinterpret_cast<uintptr_t>(fr->fn));
+    visit(reinterpret_cast<uintptr_t>(fr->pp));
+  }
+}
+
+Stack* StackPool::get() {
+  ASSERT(!used_);
+  used_ = true;
+  return &stack_;
+}
+
+StackPool* stackPool;
+
+StackPool::StackPool() {
+  heap->registerRoots(std::bind(&StackPool::accept, this, std::placeholders::_1));
+}
+
+void StackPool::put(Stack* stack) {
+  ASSERT(used_ && stack == &stack_);
+  used_ = false;
+}
+
+void StackPool::accept(std::function<void(uintptr_t)> visit) {
+  if (!used_) {
+    return;
+  }
+  stack_.accept(visit);
 }
 
 }  // namespace codeswitch

--- a/package/roots.h
+++ b/package/roots.h
@@ -6,6 +6,7 @@
 #ifndef package_roots_h
 #define package_roots_h
 
+#include <functional>
 #include "common/common.h"
 
 namespace codeswitch {
@@ -16,6 +17,8 @@ class Roots {
  public:
   Roots();
   NON_COPYABLE(Roots)
+
+  void accept(std::function<void(uintptr_t)> visit);
 
   Type* unitType = nullptr;
   Type* boolType = nullptr;

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     deps = [
         "//common",
         "//flag",
+        "//memory",  # for heap validation
         "//package",  # for init
     ],
 )

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,6 +13,7 @@
 
 #include "common/common.h"
 #include "flag/flag.h"
+#include "memory/heap.h"
 
 int main(int argc, char* argv[]) {
   codeswitch::FlagSet flags("test", "test [-run=testname]");
@@ -53,6 +54,7 @@ bool TestRunner::Run() {
     if (!t.passed()) {
       passedAll = false;
     }
+    heap->validate();
   }
   return passedAll;
 }


### PR DESCRIPTION
The heap now supports garbage collection. It counts bytes allocated,
then runs the garbage collector after that exceeds an initial
threshold (1 MB). When collection is complete, the new threshold is
set to double the number of allocated bytes.

The collector is a minimal mark-sweep design. It starts by pushing
pointers to root objects onto a mark stack. Roots come from the Roots
object, the interpreter stack, and handles. The heap uses the stack
to perform a depth-first traversal of the heap, marking live objects
on chunk marking bitmaps as it goes. When marking is complete, the
heap frees chunks with no marked objects and rebuilds free lists
on other chunks.
